### PR TITLE
Bump packages to allow successful installation and startup.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,5 @@ six==1.11.0
 SQLAlchemy==1.2.11
 urllib3==1.24.2
 virtualenv==16.0.0
-Werkzeug==0.15.3
+Werkzeug==0.16.1
 WTForms==2.2.1


### PR DESCRIPTION
cffi, MarkupSafe, numpy and Pillow contained installation problems, possibly with newer Python versions.

Werkzeug contained a breaking bug that was fixed post 0.15.4. Newer versions - post 1.0 release - introduce possibly breaking changes. 